### PR TITLE
#165289875  - Persist user transactions

### DIFF
--- a/api/controllers/staff-controller.js
+++ b/api/controllers/staff-controller.js
@@ -54,6 +54,70 @@ class staffController {
       });
     });
   }
+
+  static transactions(req, res, next) {
+    const token = req.headers['x-access-token'];
+    if (!token) return res.status(401).send({ status: 401, auth: false, msg: 'no token' });
+
+    jwt.verify(token, config.secret, (err, decoded) => {
+      if (err) return res.status(401).send({ status: 401, auth: false, msg: 'unverifiable token' });
+      const {
+        accountNumber, amount, transactionType, confirmation,
+      } = req.body;
+
+      const checkAccountNumber = 'SELECT account_number, account_status, owner FROM accounts WHERE account_number = $1 AND account_status = $2 ';
+      pool.query(checkAccountNumber, [accountNumber, 'active'], (error, result) => {
+        if (error) return next(error);
+        if (result.rows.length <= 0) return res.status(404).send({ status: 404, msg: 'invalid account' });
+      });
+
+      let oldBalance;
+      let newBalance;
+      const createdOn = new Date();
+
+      const transaction = 'SELECT * FROM transactions WHERE account_number = $1';
+      pool.query(transaction, [accountNumber], (err, content) => {
+        if (err) return next(err);
+        if (content.rows.length <= 0) {
+          const getOpeningBalance = 'SELECT * FROM accounts WHERE account_number = $1';
+          pool.query(getOpeningBalance, [accountNumber], (err, accountInfo) => {
+            if (err) return next(err);
+
+            if (transactionType === 'debit' && Number(amount) > Number(accountInfo.rows[0].balance)) { return res.status(400).send({ status: 400, msg: 'Insufficent fund' }); }
+
+            newBalance = makeTransaction(transactionType, accountInfo.rows[0].balance, amount);
+            oldBalance = accountInfo.rows[0].balance;
+
+            const saveTransactions = 'INSERT INTO transactions (created_on, transaction_type, account_number, cashier, amount, old_balance, new_balance) VALUES ($1, $2, $3, $4, $5, $6, $7)';
+            pool.query(saveTransactions, [createdOn, transactionType, accountNumber, decoded.id, amount, oldBalance, newBalance], (err, content) => {
+              if (err) return next(err);
+              return res.status(201).send({ status: 201, msg: 'transaction successful' });
+            });
+          });
+        } else {
+          let transactionFound;
+          let transactionIndex;
+
+          const transactionRecord = content.rows;
+          transactionRecord.map((lastTransaction, index) => {
+            transactionFound = lastTransaction;
+            transactionIndex = index;
+          });
+
+          newBalance = makeTransaction(transactionType, transactionFound.new_balance, amount);
+          oldBalance = transactionFound.new_balance;
+
+          if (transactionType === 'debit' && Number(amount) > Number(transactionFound.new_balance)) { return res.status(400).send({ status: 400, msg: 'Insufficent fund' }); }
+
+          const saveTransactions = 'INSERT INTO transactions (created_on, transaction_type, account_number, cashier, amount, old_balance, new_balance) VALUES ($1, $2, $3, $4, $5, $6, $7)';
+          pool.query(saveTransactions, [createdOn, transactionType, accountNumber, decoded.id, amount, oldBalance, newBalance], (err, content) => {
+            if (err) return next(err);
+            return res.status(201).send({ status: 201, msg: 'transaction successful' });
+          });
+        }
+      });
+    });
+  }
 }
 
 


### PR DESCRIPTION
#### What does this PR do?
Staff should make transactions

#### Description of Task to be completed?
Staffs will be able to complete transactions on a clients account either on debit or credit

#### How should this be manually tested?
Once the repo is cloned, on the terminal execute the command 'npm run serve'
- Launch the postman and enter this '/api/v1/transactions/<account-no>' into the url
- Fill out all the required fields
Click on send to register the user.

#### Any background context you want to provide?
NA

#### What are the relevant pivotal tracker stories?
#[165289875 ](https://www.pivotaltracker.com/story/show/165289875) [#165289999](https://www.pivotaltracker.com/story/show/165289999)

#### Screenshots (if appropriate)
NA

#### Questions:
NA