### PR TITLE
165290764 - View all account list persisted

### DIFF
--- a/api/controllers/staff-controller.js
+++ b/api/controllers/staff-controller.js
@@ -143,6 +143,28 @@ class staffController {
       });
     });
   }
+
+  static allBankAccounts(req, res, next) {
+    const token = req.headers['x-access-token'];
+    if (!token) res.status(401).send({ status: 401, msg: 'no token' });
+
+    jwt.verify(token, config.secret, (err, decoded) => {
+      if (err) res.status(401).send({ status: 401, msg: 'unverifiable token' });
+      const { id } = decoded;
+
+      const checkUser = 'SELECT email, user_type, is_admin  FROM users WHERE id = $1 AND (user_type = $2 OR is_admin = $3)';
+      pool.query(checkUser, [id, 'staff', true], (err, content) => {
+        if (err) return next(err);
+        if (content.rows.length <= 0) return res.status(401).send({ status: 401, msg: 'unauthorized user' });
+      });
+
+      const getAllAccounts = 'SELECT a.last_name, a.first_name, a.email, a.phone_no, b.account_number, b.created_on, b.account_type, b.account_status, b.balance FROM users a LEFT JOIN accounts b ON a.id = b.owner WHERE a.user_type = $1 ORDER BY a.last_name ASC';
+      pool.query(getAllAccounts, ['client'], async (error, result) => {
+        if (error) return next(error);
+        await res.status(200).send({ status: 200, data: result.rows });
+      });
+    });
+  }
 }
 
 


### PR DESCRIPTION
#### What does this PR do?
All bank accounts persisted by the users

#### Description of Task to be completed?
Staff can view all bank account list

#### How should this be manually tested?
Once the repo is cloned, on the terminal execute the command 'npm run serve'
Launch the postman and enter this '/api/v1/accounts' into the url and select the GET method

#### Any background context you want to provide?
NA

#### What are the relevant pivotal tracker stories?
[##165290764](https://www.pivotaltracker.com/story/show/165290764)

#### Screenshots (if appropriate)
NA

#### Questions:
NA